### PR TITLE
Remove link to boundlessgeo

### DIFF
--- a/_episodes_rmd/04-geo-landscape.Rmd
+++ b/_episodes_rmd/04-geo-landscape.Rmd
@@ -90,8 +90,7 @@ The [Open Source Geospatial Foundation (OSGEO)](http://www.osgeo.org/) supports 
 
 Private companies have that released SDK platforms for large scale GIS analysis:
 
- * [Kepler.gl](http://kepler.gl/#/) is Uber's toolkit for handling large datasets (i.e. Uber's data archive).
- * [Boundless Geospatial](https://boundlessgeo.com/) is built upon OSGEO software for enterprise solutions. 
+ * [Kepler.gl](http://kepler.gl/#/) is Uber's toolkit for handling large datasets (i.e. Uber's data archive). 
 
 Publically funded open-source platforms for large scale GIS analysis:
 


### PR DESCRIPTION
boundlessgeo.com redirects to Planet Federal and may no longer be appropriate for this lesson.

https://www.planet.com/
